### PR TITLE
Edit places attributes and added more flexible attribute assignation

### DIFF
--- a/lib/vamoos/api.rb
+++ b/lib/vamoos/api.rb
@@ -7,6 +7,8 @@ module Vamoos
     include ::HTTParty
     include Helpers
 
+    attr_accessor :properties
+
     VAMOOS_API_URI = 'https://live.vamoos.com/v3'
 
     class << self

--- a/lib/vamoos/helpers/attributes.rb
+++ b/lib/vamoos/helpers/attributes.rb
@@ -4,8 +4,11 @@ module Vamoos
   module Helpers
     module Attributes
       def assign_attributes(attrs)
-        attrs.deep_symbolize_keys.each do |key, value|
-          send("#{key}=", value)
+        attrs.deep_symbolize_keys.each do |attribute_name, attribute_value|
+          send("#{attribute_name}=", attribute_value)
+        rescue NoMethodError
+          self.properties ||= {}
+          self.properties[attribute_name] = attribute_value
         end
       end
     end

--- a/lib/vamoos/point_of_interest.rb
+++ b/lib/vamoos/point_of_interest.rb
@@ -3,12 +3,12 @@
 module Vamoos
   class PointOfInterest < Api
     attr_accessor :country, :country_iso, :created_at, :created_by, :description, :icon, :icon_id,
-                  :id, :is_default_on, :is_on, :itinerary_id, :latitude, :library_node, :location,
-                  :longitude, :meta, :name, :operator_id, :poi_range, :position, :timezone,
-                  :updated_at
+                  :id, :is_default_on, :is_on, :itinerary_id, :latitude, :library_node,
+                  :localisation, :location, :longitude, :meta, :name, :operator_id, :poi_range,
+                  :position, :timezone, :updated_at
 
     def initialize(attrs)
-      attrs.each { |key, value| send "#{key}=", value }
+      assign_attributes(attrs)
     end
 
     class << self

--- a/spec/lib/vamoos/helpers/attributes_spec.rb
+++ b/spec/lib/vamoos/helpers/attributes_spec.rb
@@ -25,8 +25,9 @@ RSpec.describe Vamoos::Helpers::Attributes do
 
     context 'with incorrect attributes' do
       it do
-        expect { itinerary.assign_attributes({ key: :another_value }) }.to\
-          raise_error(NoMethodError)
+        itinerary.assign_attributes({ key: :another_value })
+
+        expect(itinerary.properties).to eq({ key: :another_value })
       end
     end
   end

--- a/spec/support/fixtures/point_of_interest.json
+++ b/spec/support/fixtures/point_of_interest.json
@@ -59,5 +59,9 @@
   "is_default_on": true,
   "is_on": true,
   "poi_range": 0,
-  "meta": {}
+  "meta": {},
+  "localisation": {
+    "da": {},
+    "es": {}
+  }
 }


### PR DESCRIPTION
    Vamoos a modifié son api, ils ont ajouté un paramètre `localisation`, du coup la gem pète au moment de construire l'objet à partir de la réponse (mais l'objet est bien créé chez Vamoos)
    Trois pb :
        Ajouter le nouveau champ
        Gérer l'avenir en faisant en sorte que ça ne pète pas si ils ajoutent un champ
            Solutions envisagées :
                Rendre le attr_accessor dynamique
                Pas sûr que ça soit faisable et sécurisé
                Ne pas raise quand y'a un attribut inconnu
                    Juste l'enlever
                    L'ajouter dans un hash différent <= Solution choisie
        Faire en sorte de récupérer les données perdues (il faut remettre les `vamoos_id` dans les places qui ont pété)
            Lancer une commande pour faire un find ? A voir par la suite